### PR TITLE
Update assertj dependency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ src/test/resources/testdb.properties
 
 *.ipr
 *.iml
+/.idea/

--- a/pom.xml
+++ b/pom.xml
@@ -204,7 +204,7 @@ language governing permissions and limitations under the License.
             <!-- ASL v2.0 -->
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
-            <version>2.0.0</version>
+            <version>3.8.0</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
This updates the version of the assertj dependency from `2.0.0` to `3.8.0`.
I require a newer version to use features such as `assertThatExceptionOfType`.